### PR TITLE
OpenAIChat: Fix deprecated jcenter call

### DIFF
--- a/OpenAIChat/build.gradle
+++ b/OpenAIChat/build.gradle
@@ -37,9 +37,9 @@ compileTestKotlin {
 
 repositories {
     mavenLocal()
+    mavenCentral()
     maven { url "https://s3-eu-west-1.amazonaws.com/furhat-maven/releases"}
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
-    jcenter()
 }
 
 


### PR DESCRIPTION
Replace jcenter by mavenCentral to fix Gradle build of skill.

Related issue and PR:
https://github.com/FurhatRobotics/example-skills/issues/41 https://github.com/FurhatRobotics/example-skills/pull/42

Documentation:
https://docs.furhat.io/bintray_sundown/
https://blog.gradle.org/jcenter-shutdown